### PR TITLE
feat: implement caching

### DIFF
--- a/README.org
+++ b/README.org
@@ -80,7 +80,7 @@ Each ~Node~ contains an ~Expr~ (which maps to an actual AST item) and additional
 We take in a ~&str~ and turn it into a byte array (~&[u8]~) with a ~Cursor~. ~Cursor~ has some helpful utility functions implemented to make the parsing functions easier to write and more legible. We also avoid re-allocating the input this way.
 
 
-** Caching: TODO
+** Caching
 
 The parsing function we attempt to use can make significant progress into parsing, even accumulating child nodes of its own before failing (such as in the case of improperly closed markup).
 So in theory, we'd be heavily backtracking and re-parsing elements we've already seen!

--- a/org-exporter/src/lib.rs
+++ b/org-exporter/src/lib.rs
@@ -478,7 +478,7 @@ more content here this is a pargraph
             &mut out,
         )?;
 
-        println!("{out}");
+        // println!("{out}");
         Ok(())
     }
 

--- a/org-parser/src/element/comment.rs
+++ b/org-parser/src/element/comment.rs
@@ -1,12 +1,12 @@
 use crate::node_pool::{NodeID, NodePool};
-use crate::types::{Cursor, ParseOpts, Parseable, Result};
+use crate::types::{Cursor, ParseOpts, Parseable, Parser, Result};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Comment<'a>(pub &'a str);
 
 impl<'a> Parseable<'a> for Comment<'a> {
     fn parse(
-        pool: &mut NodePool<'a>,
+        parser: &mut Parser<'a>,
         mut cursor: Cursor<'a>,
         parent: Option<NodeID>,
         parse_opts: ParseOpts,
@@ -17,7 +17,7 @@ impl<'a> Parseable<'a> for Comment<'a> {
             let content = cursor.fn_until(|chr: u8| chr == b'\n')?;
             // TODO: use an fn_until_inclusive to not have to add 1 to the end
             // (we want to eat the ending nl too)
-            Ok(pool.alloc(Self(content.obj), cursor.index, content.end + 1, parent))
+            Ok(parser.alloc(Self(content.obj), cursor.index, content.end + 1, parent))
         } else {
             Err(crate::types::MatchError::InvalidLogic)
         }

--- a/org-parser/src/element/heading.rs
+++ b/org-parser/src/element/heading.rs
@@ -114,12 +114,19 @@ impl<'a> Parseable<'a> for Heading<'a> {
         // to trim
 
         let mut title_vec: Vec<NodeID> = Vec::new();
-        let mut temp_cursor = Cursor::new(cursor.clamp_forwards(tag_match.start).trim().as_bytes());
+        // try to trim whitespace off the beginning and end of the area
+        // we're searching
+        let mut ending = tag_match.start;
+        // >= so a no title situation is "" (blank) (we go one under, then ending + 1
+        // brings us back up)
+        while cursor[ending] == SPACE  && ending >= cursor.index {
+            ending -=1;
+        }
+        let mut temp_cursor = cursor.cut_off(ending + 1);
+        temp_cursor.skip_ws();
         while let Ok(title_id) = parse_object(
             parser,
             temp_cursor,
-            // run this song and dance to get the trim method
-            // TODO: when trim_ascii is stablized on byte_slices, use that
             Some(reserved_id),
             parse_opts,
         ) {

--- a/org-parser/src/element/keyword.rs
+++ b/org-parser/src/element/keyword.rs
@@ -1,6 +1,6 @@
 use crate::constants::COLON;
 use crate::node_pool::{NodeID, NodePool};
-use crate::types::{Cursor, MatchError, ParseOpts, Parseable, Result};
+use crate::types::{Cursor, MatchError, ParseOpts, Parseable, Parser, Result};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Keyword<'a> {
@@ -10,7 +10,7 @@ pub struct Keyword<'a> {
 
 impl<'a> Parseable<'a> for Keyword<'a> {
     fn parse(
-        pool: &mut NodePool<'a>,
+        parser: &mut Parser<'a>,
         mut cursor: Cursor<'a>,
         parent: Option<NodeID>,
         parse_opts: ParseOpts,
@@ -26,7 +26,7 @@ impl<'a> Parseable<'a> for Keyword<'a> {
                 let val = cursor.fn_until(|chr: u8| chr == b'\n')?;
                 // TODO: use an fn_until_inclusive to not have to add 1 to the end
                 // (we want to eat the ending nl too)
-                Ok(pool.alloc(
+                Ok(parser.alloc(
                     Self {
                         key: key_word.obj,
                         // not mentioned in the spec, but org-element trims

--- a/org-parser/src/element/latex_env.rs
+++ b/org-parser/src/element/latex_env.rs
@@ -2,7 +2,7 @@ use memchr::memmem;
 
 use crate::constants::{NEWLINE, RBRACE, STAR};
 use crate::node_pool::{NodeID, NodePool};
-use crate::types::{Cursor, MatchError, ParseOpts, Parseable, Result};
+use crate::types::{Cursor, MatchError, ParseOpts, Parseable, Parser, Result};
 
 #[derive(Debug, Clone, Copy)]
 pub struct LatexEnv<'a> {
@@ -12,7 +12,7 @@ pub struct LatexEnv<'a> {
 
 impl<'a> Parseable<'a> for LatexEnv<'a> {
     fn parse(
-        pool: &mut NodePool<'a>,
+        parser: &mut Parser<'a>,
         mut cursor: Cursor<'a>,
         parent: Option<NodeID>,
         parse_opts: ParseOpts,
@@ -72,7 +72,7 @@ impl<'a> Parseable<'a> for LatexEnv<'a> {
             cursor.index = loc;
         }
 
-        Ok(pool.alloc(
+        Ok(parser.alloc(
             Self {
                 name,
                 // + 1 to skip newline

--- a/org-parser/src/element/paragraph.rs
+++ b/org-parser/src/element/paragraph.rs
@@ -1,13 +1,13 @@
 use crate::node_pool::{NodeID, NodePool};
 use crate::parse::parse_object;
-use crate::types::{Cursor, ParseOpts, Parseable, Result};
+use crate::types::{Cursor, ParseOpts, Parseable, Parser, Result};
 
 #[derive(Debug, Clone)]
 pub struct Paragraph(pub Vec<NodeID>);
 
 impl<'a> Parseable<'a> for Paragraph {
     fn parse(
-        pool: &mut NodePool<'a>,
+        parser: &mut Parser<'a>,
         mut cursor: Cursor<'a>,
         parent: Option<NodeID>,
         mut parse_opts: ParseOpts,
@@ -17,14 +17,14 @@ impl<'a> Parseable<'a> for Paragraph {
         parse_opts.from_paragraph = true;
 
         // allocte beforehand since we know paragrpah can never fail
-        let new_id = pool.reserve_id();
+        let new_id = parser.pool.reserve_id();
 
-        while let Ok(id) = parse_object(pool, cursor, Some(new_id), parse_opts) {
-            cursor.index = pool[id].end;
+        while let Ok(id) = parse_object(parser, cursor, Some(new_id), parse_opts) {
+            cursor.index = parser.pool[id].end;
             content_vec.push(id);
         }
 
-        Ok(pool.alloc_with_id(
+        Ok(parser.alloc_with_id(
             Paragraph(content_vec),
             start,
             cursor.index + 1, // newline

--- a/org-parser/src/node_pool.rs
+++ b/org-parser/src/node_pool.rs
@@ -13,8 +13,6 @@ impl std::fmt::Debug for NodeID {
     }
 }
 
-type Cache = HashMap<u32, NodeID>;
-
 #[derive(Debug)]
 pub struct NodePool<'a> {
     pub inner_vec: Vec<Node<'a>>,
@@ -30,7 +28,13 @@ impl<'a> NodePool<'a> {
         }
     }
 
-    pub(crate) fn alloc<T>(&mut self, obj: T, start: usize, end: usize, parent: Option<NodeID>) -> NodeID
+    pub(crate) fn alloc<T>(
+        &mut self,
+        obj: T,
+        start: usize,
+        end: usize,
+        parent: Option<NodeID>,
+    ) -> NodeID
     where
         Expr<'a>: From<T>,
     {

--- a/org-parser/src/object/inline_src.rs
+++ b/org-parser/src/object/inline_src.rs
@@ -1,6 +1,6 @@
 use crate::constants::{LBRACE, LBRACK, NEWLINE, RBRACE, RBRACK};
 use crate::node_pool::{NodeID, NodePool};
-use crate::types::{Cursor, MatchError, ParseOpts, Parseable, Result};
+use crate::types::{Cursor, MatchError, ParseOpts, Parseable, Parser, Result};
 use crate::utils::Match;
 
 #[derive(Debug, Clone, Copy)]
@@ -12,7 +12,7 @@ pub struct InlineSrc<'a> {
 
 impl<'a> Parseable<'a> for InlineSrc<'a> {
     fn parse(
-        pool: &mut NodePool<'a>,
+        parser: &mut Parser<'a>,
         mut cursor: Cursor<'a>,
         parent: Option<NodeID>,
         parse_opts: ParseOpts,
@@ -30,7 +30,7 @@ impl<'a> Parseable<'a> for InlineSrc<'a> {
         match cursor.curr() {
             LBRACE => {
                 let body = Self::parse_body(cursor)?;
-                Ok(pool.alloc(
+                Ok(parser.alloc(
                     Self {
                         lang: body.obj,
                         headers: None,
@@ -46,7 +46,7 @@ impl<'a> Parseable<'a> for InlineSrc<'a> {
                 cursor.move_to(header.end);
                 if cursor.curr() != LBRACE {
                     let body = Self::parse_body(cursor)?;
-                    Ok(pool.alloc(
+                    Ok(parser.alloc(
                         Self {
                             lang: lang.obj,
                             headers: Some(header.obj),

--- a/org-parser/src/parse.rs
+++ b/org-parser/src/parse.rs
@@ -11,11 +11,11 @@ use crate::object::{
     parse_angle_link, parse_plain_link, Bold, Code, Italic, LatexFragment, RegularLink,
     StrikeThrough, Underline, Verbatim,
 };
-use crate::types::{Cursor, Expr, MarkupKind, MatchError, ParseOpts, Parseable, Result};
+use crate::types::{Cursor, Expr, MarkupKind, MatchError, ParseOpts, Parseable, Parser, Result};
 use crate::utils::verify_markup;
 
 pub(crate) fn parse_element<'a>(
-    pool: &mut NodePool<'a>,
+    parser: &mut Parser<'a>,
     mut cursor: Cursor<'a>,
     parent: Option<NodeID>,
     parse_opts: ParseOpts,
@@ -25,7 +25,7 @@ pub(crate) fn parse_element<'a>(
     // means a newline checking thing called this, and newline breaks all
     // table rows
     if parse_opts.markup.contains(MarkupKind::Table) {
-        return Ok(pool.alloc(MarkupKind::Table, cursor.index, cursor.index + 1, None));
+        return Ok(parser.alloc(MarkupKind::Table, cursor.index, cursor.index + 1, None));
     }
 
     // indentation check
@@ -35,7 +35,7 @@ pub(crate) fn parse_element<'a>(
         let byte = cursor[indented_loc];
         if byte.is_ascii_whitespace() {
             if byte == NEWLINE {
-                return Ok(pool.alloc(Expr::BlankLine, cursor.index, indented_loc + 1, parent));
+                return Ok(parser.alloc(Expr::BlankLine, cursor.index, indented_loc + 1, parent));
             } else {
                 new_opts.indentation_level += 1;
                 indented_loc += 1;
@@ -56,7 +56,7 @@ pub(crate) fn parse_element<'a>(
     if !parse_opts.list_line {
         if indentation_level + 1 == parse_opts.indentation_level.into() && parse_opts.from_list {
             if let ret @ Ok(_) =
-                Item::parse(pool, cursor.move_to_copy(indented_loc), parent, new_opts)
+                Item::parse(parser, cursor.move_to_copy(indented_loc), parent, new_opts)
             {
                 return ret;
             } else {
@@ -74,44 +74,45 @@ pub(crate) fn parse_element<'a>(
             // parse_opts, (doesn't totally matter to use the default vs preloaded,
             // since we account for it, but default makes more sense maybe>?)
             if (indentation_level) > 0 {
-                if let ret @ Ok(_) = PlainList::parse(pool, cursor, parent, parse_opts) {
+                if let ret @ Ok(_) = PlainList::parse(parser, cursor, parent, parse_opts) {
                     return ret;
                 }
-            } else if let ret @ Ok(_) = Heading::parse(pool, cursor, parent, ParseOpts::default()) {
+            } else if let ret @ Ok(_) = Heading::parse(parser, cursor, parent, ParseOpts::default())
+            {
                 return ret;
             }
         }
         PLUS => {
-            if let ret @ Ok(_) = PlainList::parse(pool, cursor, parent, new_opts) {
+            if let ret @ Ok(_) = PlainList::parse(parser, cursor, parent, new_opts) {
                 return ret;
             }
         }
         HYPHEN => {
-            if let ret @ Ok(_) = PlainList::parse(pool, cursor, parent, new_opts) {
+            if let ret @ Ok(_) = PlainList::parse(parser, cursor, parent, new_opts) {
                 return ret;
             }
         }
         chr if chr.is_ascii_digit() => {
-            if let ret @ Ok(_) = PlainList::parse(pool, cursor, parent, new_opts) {
+            if let ret @ Ok(_) = PlainList::parse(parser, cursor, parent, new_opts) {
                 return ret;
             }
         }
         POUND => {
-            if let ret @ Ok(_) = Keyword::parse(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = Keyword::parse(parser, cursor, parent, parse_opts) {
                 return ret;
-            } else if let ret @ Ok(_) = Block::parse(pool, cursor, parent, parse_opts) {
+            } else if let ret @ Ok(_) = Block::parse(parser, cursor, parent, parse_opts) {
                 return ret;
-            } else if let ret @ Ok(_) = Comment::parse(pool, cursor, parent, parse_opts) {
+            } else if let ret @ Ok(_) = Comment::parse(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
         BACKSLASH => {
-            if let ret @ Ok(_) = LatexEnv::parse(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = LatexEnv::parse(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
         VBAR => {
-            if let ret @ Ok(_) = Table::parse(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = Table::parse(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
@@ -119,59 +120,64 @@ pub(crate) fn parse_element<'a>(
     }
 
     if !parse_opts.from_paragraph {
-        Paragraph::parse(pool, cursor, parent, parse_opts)
+        Paragraph::parse(parser, cursor, parent, parse_opts)
     } else {
         Err(MatchError::InvalidLogic)
     }
 }
 
 macro_rules! handle_markup {
-    ($name: tt, $pool: ident, $cursor: ident, $parent: ident, $parse_opts: ident) => {
+    ($name: tt, $parser: ident, $cursor: ident, $parent: ident, $parse_opts: ident) => {
         if $parse_opts.markup.contains(MarkupKind::$name) {
             // None parent cause this
             // FIXME: we allocate in the pool for "marker" return types,,
             if verify_markup($cursor, true) {
-                return Ok($pool.alloc(MarkupKind::$name, $cursor.index, $cursor.index + 1, None));
+                return Ok($parser.alloc(
+                    MarkupKind::$name,
+                    $cursor.index,
+                    $cursor.index + 1,
+                    None,
+                ));
             } else {
                 return Err(MatchError::InvalidLogic);
             }
-        } else if let ret @ Ok(_) = $name::parse($pool, $cursor, $parent, $parse_opts) {
+        } else if let ret @ Ok(_) = $name::parse($parser, $cursor, $parent, $parse_opts) {
             return ret;
         }
     };
 }
 
 pub(crate) fn parse_object<'a>(
-    pool: &mut NodePool<'a>,
+    parser: &mut Parser<'a>,
     cursor: Cursor<'a>,
     parent: Option<NodeID>,
     mut parse_opts: ParseOpts,
 ) -> Result<NodeID> {
     match cursor.try_curr()? {
         SLASH => {
-            handle_markup!(Italic, pool, cursor, parent, parse_opts);
+            handle_markup!(Italic, parser, cursor, parent, parse_opts);
         }
         STAR => {
-            handle_markup!(Bold, pool, cursor, parent, parse_opts);
+            handle_markup!(Bold, parser, cursor, parent, parse_opts);
         }
         UNDERSCORE => {
-            handle_markup!(Underline, pool, cursor, parent, parse_opts);
+            handle_markup!(Underline, parser, cursor, parent, parse_opts);
         }
         PLUS => {
-            handle_markup!(StrikeThrough, pool, cursor, parent, parse_opts);
+            handle_markup!(StrikeThrough, parser, cursor, parent, parse_opts);
         }
         EQUAL => {
-            if let ret @ Ok(_) = Verbatim::parse(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = Verbatim::parse(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
         TILDE => {
-            if let ret @ Ok(_) = Code::parse(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = Code::parse(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
         LBRACK => {
-            if let ret @ Ok(_) = RegularLink::parse(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = RegularLink::parse(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
@@ -183,7 +189,7 @@ pub(crate) fn parse_object<'a>(
                 // FIXME: we allocate in the pool for "marker" return types,,
                 if let Ok(byte) = cursor.peek(1) {
                     if byte == RBRACK {
-                        return Ok(pool.alloc(
+                        return Ok(parser.alloc(
                             MarkupKind::Link,
                             cursor.index,
                             cursor.index + 2,
@@ -194,12 +200,12 @@ pub(crate) fn parse_object<'a>(
             }
         }
         BACKSLASH => {
-            if let ret @ Ok(_) = LatexFragment::parse(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = LatexFragment::parse(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
         DOLLAR => {
-            if let ret @ Ok(_) = LatexFragment::parse(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = LatexFragment::parse(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
@@ -211,9 +217,14 @@ pub(crate) fn parse_object<'a>(
             // this earlier? any other affected elements?
             parse_opts.from_object = false;
 
-            match parse_element(pool, cursor.adv_copy(1), parent, parse_opts) {
+            match parse_element(parser, cursor.adv_copy(1), parent, parse_opts) {
                 Err(MatchError::InvalidLogic) => {
-                    return Ok(pool.alloc(Expr::SoftBreak, cursor.index, cursor.index + 1, parent));
+                    return Ok(parser.alloc(
+                        Expr::SoftBreak,
+                        cursor.index,
+                        cursor.index + 1,
+                        parent,
+                    ));
                 }
                 // EofError isn't exactly the right error for the Ok(_) case
                 // but we do it to send a signal to `parse_text` to stop collecting:
@@ -223,20 +234,20 @@ pub(crate) fn parse_object<'a>(
             }
         }
         LANGLE => {
-            if let ret @ Ok(_) = parse_angle_link(pool, cursor, parent, parse_opts) {
+            if let ret @ Ok(_) = parse_angle_link(parser, cursor, parent, parse_opts) {
                 return ret;
             }
         }
         VBAR => {
             if parse_opts.markup.contains(MarkupKind::Table) {
-                return Ok(pool.alloc(MarkupKind::Table, cursor.index, cursor.index + 1, None));
+                return Ok(parser.alloc(MarkupKind::Table, cursor.index, cursor.index + 1, None));
             }
         }
         _ => {}
     }
 
     if let Ok(plain_link_match) = parse_plain_link(cursor) {
-        return Ok(pool.alloc(
+        return Ok(parser.alloc(
             plain_link_match.obj,
             cursor.index,
             plain_link_match.end,
@@ -248,21 +259,21 @@ pub(crate) fn parse_object<'a>(
         Err(MatchError::InvalidLogic)
     } else {
         parse_opts.from_object = true;
-        Ok(parse_text(pool, cursor, parent, parse_opts))
+        Ok(parse_text(parser, cursor, parent, parse_opts))
     }
 }
 
 fn parse_text<'a>(
-    pool: &mut NodePool<'a>,
+    parser: &mut Parser<'a>,
     mut cursor: Cursor<'a>,
     parent: Option<NodeID>,
     parse_opts: ParseOpts,
 ) -> NodeID {
     let start = cursor.index;
 
-    while let Err(MatchError::InvalidLogic) = parse_object(pool, cursor, parent, parse_opts) {
+    while let Err(MatchError::InvalidLogic) = parse_object(parser, cursor, parent, parse_opts) {
         cursor.next();
     }
 
-    pool.alloc(cursor.clamp_backwards(start), start, cursor.index, parent)
+    parser.alloc(cursor.clamp_backwards(start), start, cursor.index, parent)
 }

--- a/org-parser/src/parse.rs
+++ b/org-parser/src/parse.rs
@@ -20,8 +20,11 @@ pub(crate) fn parse_element<'a>(
     parent: Option<NodeID>,
     parse_opts: ParseOpts,
 ) -> Result<NodeID> {
-    cursor.is_index_valid()?;
+    if let Some(id) = parser.cache.get(&cursor.index) {
+        return Ok(*id);
+    }
 
+    cursor.is_index_valid()?;
     // means a newline checking thing called this, and newline breaks all
     // table rows
     if parse_opts.markup.contains(MarkupKind::Table) {
@@ -153,6 +156,10 @@ pub(crate) fn parse_object<'a>(
     parent: Option<NodeID>,
     mut parse_opts: ParseOpts,
 ) -> Result<NodeID> {
+    if let Some(id) = parser.cache.get(&cursor.index) {
+        return Ok(*id);
+    }
+
     match cursor.try_curr()? {
         SLASH => {
             handle_markup!(Italic, parser, cursor, parent, parse_opts);


### PR DESCRIPTION
was stalling on this until i felt comfortable enough with the impl.

brings our expected runtime from exponential to linear. this is reflected by the `beeg` test, which saw
```
now:

        PASS [   0.003s] org-exporter tests::test_beeg

before:

        PASS [   2.831s] org-exporter tests::test_beeg
```
its runtime drop by several orders of magnitude.

caching prevents insane amount of reparsing since the program was designed with parsing in mind. saves on both runtime and memory, since allocated nodes aren't dropped until the end of the program ;p