### PR TITLE
feat: improve resilience of the parser

### DIFF
--- a/crates/org-cli/Cargo.toml
+++ b/crates/org-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "org-rust"
-version = "0.1.16"
+version = "0.1.17"
 description = "CLI tool for converting Org-Mode documents to other formats"
 keywords = ["org-mode", "parser"]
 categories = ["command-line-utilities"]
@@ -18,8 +18,8 @@ rust-version.workspace = true
 clap = { version = "4.3.11", features = ["derive"] }
 lazy_format = "2.0.0"
 regex = "1.9.5"
-org-exporter = { version = "0.1.6", path = "../org-exporter", package = "org-rust-exporter" }
-org-parser =   { version = "0.1.4", path = "../org-parser", package = "org-rust-parser" }
+org-exporter = { version = "0.1.8", path = "../org-exporter", package = "org-rust-exporter" }
+org-parser =   { version = "0.1.5", path = "../org-parser", package = "org-rust-parser" }
 serde = { version = "1.0.196", features=["derive"]}
 toml = "0.8.8"
 anyhow = "1.0.82"
@@ -30,8 +30,8 @@ clap = { version = "4.3.11", features=["derive"]}
 clap_complete = "4.3.2"
 clap_mangen = "0.2.14"
 serde = { version = "1.0.196", features=["derive"]}
-org-exporter = { version = "0.1.2", path = "../org-exporter", package = "org-rust-exporter" }
-org-parser =   { version = "0.1.2", path = "../org-parser", package = "org-rust-parser" }
+org-exporter = { version = "0.1.8", path = "../org-exporter", package = "org-rust-exporter" }
+org-parser =   { version = "0.1.5", path = "../org-parser", package = "org-rust-parser" }
 
 
 # [[bin]]

--- a/crates/org-cli/src/cli.rs
+++ b/crates/org-cli/src/cli.rs
@@ -51,7 +51,7 @@ impl Backend {
         parsed: &org_parser::Parser,
         buf: &mut String,
         conf: ConfigOptions
-    ) -> Result<(), org_exporter::ExportError> {
+    ) -> Result<(), Vec<org_exporter::ExportError>> {
         match self {
             Backend::Html => org_exporter::Html::export_tree(parsed, buf, conf),
             Backend::Org => org_exporter::Org::export_tree(parsed, buf, conf),

--- a/crates/org-cli/src/cli.rs
+++ b/crates/org-cli/src/cli.rs
@@ -51,7 +51,7 @@ impl Backend {
         parsed: &org_parser::Parser,
         buf: &mut String,
         conf: ConfigOptions
-    ) -> Result<(), core::fmt::Error> {
+    ) -> Result<(), org_exporter::ExportError> {
         match self {
             Backend::Html => org_exporter::Html::export_tree(parsed, buf, conf),
             Backend::Org => org_exporter::Org::export_tree(parsed, buf, conf),

--- a/crates/org-cli/src/main.rs
+++ b/crates/org-cli/src/main.rs
@@ -161,7 +161,14 @@ fn run() -> anyhow::Result<()> {
             }
 
             let conf = ConfigOptions::new(Some(file_path.to_path_buf()));
-            backend.export(&parser_output, &mut exported_content, conf)?;
+            if let Err(err_vec) = backend.export(&parser_output, &mut exported_content, conf) {
+                let mut build_str = String::new();
+                for e in err_vec {
+                    build_str.push_str(&e.to_string());
+                    build_str.push_str("\n");
+                }
+                Err(CliError::new().with_cause(&build_str))?
+            }
 
             // handle a template (if needed)
             if let Some(template_path) = parser_output.keywords.get("template_path") {

--- a/crates/org-cli/src/template.rs
+++ b/crates/org-cli/src/template.rs
@@ -243,10 +243,10 @@ impl<'a, 'template> Template<'a, 'template> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
 
-    #[test]
-    fn bad_template() {}
-}
+//     #[test]
+//     fn bad_template() {}
+// }

--- a/crates/org-cli/src/utils.rs
+++ b/crates/org-cli/src/utils.rs
@@ -8,7 +8,7 @@ use crate::types::CliError;
 // a fs::canonicalize that doesnt care for existince. used for error handling
 // yanked straight from:
 // https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
-pub fn normalize_path(path: &Path) -> PathBuf {
+pub fn _normalize_path(path: &Path) -> PathBuf {
     let mut components = path.components().peekable();
     let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
         components.next();

--- a/crates/org-exporter/Cargo.toml
+++ b/crates/org-exporter/Cargo.toml
@@ -16,6 +16,7 @@ latex2mathml = "0.2.3"
 memchr = "2.5.0"
 org-parser = { version = "0.1.3", path = "../org-parser", package = "org-rust-parser" }
 phf = {version = "0.11.1", features = ["macros"]}
+thiserror = "1.0.63"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/crates/org-exporter/Cargo.toml
+++ b/crates/org-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "org-rust-exporter"
-version = "0.1.7"
+version = "0.1.8"
 description = "exporter for org mode documents parsed with `org-rust-parser`"
 
 homepage.workspace = true
@@ -14,7 +14,7 @@ rust-version.workspace = true
 [dependencies]
 latex2mathml = "0.2.3"
 memchr = "2.5.0"
-org-parser = { version = "0.1.3", path = "../org-parser", package = "org-rust-parser" }
+org-parser = { version = "0.1.5", path = "../org-parser", package = "org-rust-parser" }
 phf = {version = "0.11.1", features = ["macros"]}
 thiserror = "1.0.63"
 

--- a/crates/org-exporter/src/html.rs
+++ b/crates/org-exporter/src/html.rs
@@ -541,18 +541,15 @@ impl<'buf> ExporterInner<'buf> for Html<'buf> {
                 }
             }
             Expr::LatexEnv(inner) => {
-                let ret = latex_to_mathml(
-                    &format!(
-                        r"\begin{{{0}}}
+                let formatted = &format!(
+                    r"\begin{{{0}}}
 {1}
 \end{{{0}}}
 ",
-                        inner.name, inner.contents
-                    ),
-                    DisplayStyle::Block,
-                )
-                .unwrap();
-                writeln!(self, "{ret}")?;
+                    inner.name, inner.contents
+                );
+                let ret = latex_to_mathml(&formatted, DisplayStyle::Block);
+                writeln!(self, "{}", if let Ok(val) = &ret { val } else { formatted })?;
             }
             Expr::LatexFragment(inner) => match inner {
                 LatexFragment::Command { name, contents } => {

--- a/crates/org-exporter/src/include.rs
+++ b/crates/org-exporter/src/include.rs
@@ -197,7 +197,7 @@ pub(crate) fn include_handle<'a>(
         temp_path
             .canonicalize()
             .map_err(|e| FileError {
-                context: "failed to locate file".into(),
+                context: "".into(),
                 path: temp_path,
                 source: e,
             })?
@@ -206,7 +206,7 @@ pub(crate) fn include_handle<'a>(
         ret.file.into()
     };
     let mut out_str = read_to_string(&target_path).map_err(|e| FileError {
-        context: "failed to read file".into(),
+        context: "".into(),
         path: target_path.into(),
         source: e,
     })?;

--- a/crates/org-exporter/src/include.rs
+++ b/crates/org-exporter/src/include.rs
@@ -275,9 +275,8 @@ pub(crate) fn include_handle<'a>(
     // TODO: only-contents
 
     parsed = parse_org(&feed_str);
-    writer
-        .export_rec(&parsed.pool.root_id(), &parsed)
-        .map_err(|e| Box::new(e))?;
+    // TODO/FIXME: expose these errors
+    writer.export_rec(&parsed.pool.root_id(), &parsed);
 
     Ok(())
 }

--- a/crates/org-exporter/src/include.rs
+++ b/crates/org-exporter/src/include.rs
@@ -300,6 +300,6 @@ pub enum IncludeError {
     NotStringMinlevel(String),
     #[error("{0}")]
     IoError(#[from] FileError),
-    #[error("{0}")]
+    #[error("failure while handling file {0}")]
     FileExport(#[from] Box<ExportError>),
 }

--- a/crates/org-exporter/src/lib.rs
+++ b/crates/org-exporter/src/lib.rs
@@ -8,23 +8,23 @@
 //!
 //! ```rust
 //! use org_rust_exporter as org_exporter;
-//! use org_exporter::{Html, Org, Exporter};
+//! use org_exporter::{Html, Org, Exporter, ConfigOptions};
 //!
-//! let html_str: String = Html::export("* Hello HTML!\n").unwrap();
-//! let org_str: String = Org::export("* Hello Org!\n").unwrap();
+//! let html_str: String = Html::export("* Hello HTML!\n", ConfigOptions::default()).unwrap();
+//! let org_str: String = Org::export("* Hello Org!\n", ConfigOptions::default()).unwrap();
 //! ```
 //!
 //! You can also export into a buffer that implements [`fmt::Write`]:
 //!
 //! ```rust
 //! use org_rust_exporter as org_exporter;
-//! use org_exporter::{Html, Org, Exporter};
+//! use org_exporter::{Html, Org, Exporter, ConfigOptions};
 //!
 //! let mut html_str = String::new();
 //! let mut org_str = String::new();
 //!
-//! Html::export_buf("* Hello HTML!\n", &mut html_str);
-//! Org::export_buf("* Hello Org!\n", &mut org_str);
+//! Html::export_buf("* Hello HTML!\n", &mut html_str, ConfigOptions::default());
+//! Org::export_buf("* Hello Org!\n", &mut org_str, ConfigOptions::default());
 //!
 //! assert_eq!(html_str, r#"<h1 id="hello-html">Hello HTML!</h1>
 //! "#);

--- a/crates/org-exporter/src/lib.rs
+++ b/crates/org-exporter/src/lib.rs
@@ -40,4 +40,4 @@ mod utils;
 
 pub use html::Html;
 pub use org::Org;
-pub use types::{Exporter, ConfigOptions};
+pub use types::{ConfigOptions, ExportError, Exporter};

--- a/crates/org-exporter/src/org_macros.rs
+++ b/crates/org-exporter/src/org_macros.rs
@@ -113,7 +113,7 @@ pub(crate) fn keyword_file<'a>(
         temp_path
             .canonicalize()
             .map_err(|e| FileError {
-                context: "failed to locate file".into(),
+                context: "Error during macro invocation of kw-file. ".into(),
                 path: temp_path,
                 source: e,
             })?
@@ -123,7 +123,7 @@ pub(crate) fn keyword_file<'a>(
     };
 
     let out_str = read_to_string(&target_path).map_err(|e| FileError {
-        context: "failed to read file".into(),
+        context: "Error during macro invocation of kw-file. ".into(),
         path: target_path.into(),
         source: e,
     })?;
@@ -137,11 +137,11 @@ pub(crate) fn keyword_file<'a>(
 
 #[derive(Error, Debug)]
 pub enum MacroError {
-    #[error("no matching value found for keyword, {kw}")]
+    #[error("no matching value found for keyword `{kw}`")]
     Keyword { kw: String },
     #[error("expected {expected} params, received {received} instead")]
     InvalidParameters { expected: usize, received: usize },
-    #[error("macro: {name}, does not exist")]
+    #[error("call to invalid macro `{name}`")]
     UndefinedMacro { name: String },
     #[error("{0}")]
     IoError(#[from] FileError),

--- a/crates/org-exporter/src/org_macros.rs
+++ b/crates/org-exporter/src/org_macros.rs
@@ -5,6 +5,9 @@ use std::borrow::Cow;
 use std::fs::read_to_string;
 use std::path::Path;
 
+use thiserror::Error;
+
+use crate::types::FileError;
 use crate::utils::keyword_lookup;
 use crate::ConfigOptions;
 
@@ -12,10 +15,26 @@ pub(crate) fn macro_handle<'a>(
     parser: &'a Parser,
     macro_call: &'a MacroCall,
     config: &ConfigOptions,
-) -> Result<Cow<'a, str>, Box<dyn std::error::Error>> {
+) -> Result<Cow<'a, str>, MacroError> {
     match macro_call.name {
-        "keyword" => keyword_macro(parser, &macro_call.args[0]),
-        "kw-file" => keyword_file(&macro_call.args[0], &macro_call.args[1], config),
+        "keyword" => {
+            if macro_call.args.len() != 1 {
+                Err(MacroError::InvalidParameters {
+                    expected: 1,
+                    received: macro_call.args.len(),
+                })?
+            }
+            keyword_macro(parser, &macro_call.args[0])
+        }
+        "kw-file" => {
+            if macro_call.args.len() != 2 {
+                Err(MacroError::InvalidParameters {
+                    expected: 2,
+                    received: macro_call.args.len(),
+                })?
+            }
+            keyword_file(&macro_call.args[0], &macro_call.args[1], config)
+        }
         special_keyword @ ("title" | "author" | "email") => {
             if macro_call.args.is_empty() {
                 keyword_macro(parser, special_keyword)
@@ -30,16 +49,21 @@ pub(crate) fn macro_handle<'a>(
 pub(crate) fn macro_execute<'a>(
     parser: &'a Parser,
     macro_call: &MacroCall<'a>,
-) -> Result<Cow<'a, str>, Box<dyn std::error::Error>> {
-    let mac_def = parser.macros.get(macro_call.name).unwrap();
-    // FIXME: pretty janky, but have to do this dance to get the macrodef for the macrocall
+) -> Result<Cow<'a, str>, MacroError> {
+    let mac_def = parser
+        .macros
+        .get(macro_call.name)
+        .ok_or(MacroError::UndefinedMacro {
+            name: macro_call.name.into(),
+        })?;
 
-    // if let Expr::MacroDef(mac_def) = &parser.pool[*macid].obj {
-    if macro_call.args.len() == mac_def.num_args as usize {
-        Ok(apply(mac_def, &macro_call.args))
-    } else {
-        unreachable!("darn")
+    if macro_call.args.len() != mac_def.num_args as usize {
+        Err(MacroError::InvalidParameters {
+            expected: mac_def.num_args as usize,
+            received: macro_call.args.len(),
+        })?
     }
+    Ok(apply(mac_def, &macro_call.args))
 
     // }
 }
@@ -70,34 +94,55 @@ pub fn apply<'a>(macro_def: &MacroDef, args: &[Cow<'a, str>]) -> Cow<'a, str> {
 pub(crate) fn keyword_macro<'a>(
     parser: &'a Parser,
     name: &'a str,
-) -> Result<Cow<'a, str>, Box<dyn std::error::Error>> {
-    // not finding a keyword doesn't blow up the exporter in org-mode
-    //
-    // TODO: warning system so invalid macros are caught
-    Ok(keyword_lookup(parser, name)
+) -> Result<Cow<'a, str>, MacroError> {
+    keyword_lookup(parser, name)
         .map(|x| x.into())
-        .expect("whoops"))
+        .ok_or(MacroError::Keyword { kw: name.into() })
 }
 
-pub fn keyword_file<'a>(
+pub(crate) fn keyword_file<'a>(
     kw: &'a str,
     file: &'a str,
     config: &ConfigOptions,
-) -> Result<Cow<'a, str>, Box<dyn std::error::Error>> {
+) -> Result<Cow<'a, str>, MacroError> {
     let path = Path::new(file.trim());
 
     let target_path: Cow<Path> = if let Some(v) = config.file_path().as_ref() {
         // TODO: error handling
-        v.parent().unwrap().join(path).canonicalize()?.into()
+        let temp_path = v.parent().unwrap().join(path);
+        temp_path
+            .canonicalize()
+            .map_err(|e| FileError {
+                context: "failed to locate file".into(),
+                path: temp_path,
+                source: e,
+            })?
+            .into()
     } else {
         path.into()
     };
 
-    let out_str = read_to_string(target_path)?;
+    let out_str = read_to_string(&target_path).map_err(|e| FileError {
+        context: "failed to read file".into(),
+        path: target_path.into(),
+        source: e,
+    })?;
     let parsed = org_parser::parse_org(&out_str);
-    if let Some(&val) = parsed.keywords.get(kw) {
-        Ok(Cow::from(val.to_owned()))
-    } else {
-        todo!("whoopsies")
-    }
+    parsed
+        .keywords
+        .get(kw)
+        .map(|&f| f.to_owned().into())
+        .ok_or(MacroError::Keyword { kw: kw.into() })
+}
+
+#[derive(Error, Debug)]
+pub enum MacroError {
+    #[error("no matching value found for keyword, {kw}")]
+    Keyword { kw: String },
+    #[error("expected {expected} params, received {received} instead")]
+    InvalidParameters { expected: usize, received: usize },
+    #[error("macro: {name}, does not exist")]
+    UndefinedMacro { name: String },
+    #[error("{0}")]
+    IoError(#[from] FileError),
 }

--- a/crates/org-exporter/src/types.rs
+++ b/crates/org-exporter/src/types.rs
@@ -1,12 +1,43 @@
 use core::fmt;
-use std::path::PathBuf;
-
 use org_parser::{NodeID, Parser};
+use std::{ops::Range, path::PathBuf};
+use thiserror::Error;
+
+pub(crate) type Result<T> = core::result::Result<T, ExportError>;
+
+use crate::{include::IncludeError, org_macros::MacroError};
 
 #[derive(Debug, Clone, Default)]
 pub struct ConfigOptions {
     /// Used for evaluating relative paths in #+include: statements
     file_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Error)]
+pub enum ExportError {
+    #[error("{0}-{1}: {source}", span.start, span.end)]
+    LogicError {
+        span: Range<usize>,
+        source: LogicErrorKind,
+    },
+    #[error("{0}")]
+    WriteError(#[from] fmt::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum LogicErrorKind {
+    #[error("{0}")]
+    Include(#[from] IncludeError),
+    #[error("{0}")]
+    Macro(#[from] MacroError),
+}
+
+#[derive(Debug, Error)]
+#[error("{context} {path}: {source}")]
+pub struct FileError {
+    pub context: String,
+    pub path: PathBuf,
+    pub source: std::io::Error,
 }
 
 impl ConfigOptions {
@@ -23,18 +54,21 @@ impl ConfigOptions {
 /// Exporting backends must implement this trait.
 pub trait Exporter<'buf> {
     /// Writes the AST generated from the input into a `String`.
-    fn export(input: &str, conf: ConfigOptions) -> core::result::Result<String, fmt::Error>;
+    fn export(input: &str, conf: ConfigOptions) -> Result<String>;
     /// Writes the AST generated from the input into a buffer that implements `Write`.
     fn export_buf<'inp, T: fmt::Write>(
         input: &'inp str,
         buf: &'buf mut T,
         conf: ConfigOptions,
-    ) -> fmt::Result;
+    ) -> Result<()>;
     fn export_tree<T: fmt::Write>(
         parsed: &Parser,
         buf: &'buf mut T,
         conf: ConfigOptions,
-    ) -> fmt::Result;
+    ) -> Result<()>;
+
+    // fn errors(&self) -> Vec<ExportError>;
+    // fn warnings(&self);
 }
 
 /// Private interface for Exporter types.
@@ -47,11 +81,11 @@ pub(crate) trait ExporterInner<'buf> {
         input: &'inp str,
         buf: &'buf mut T,
         conf: ConfigOptions,
-    ) -> fmt::Result;
+    ) -> Result<()>;
     /// Primary exporting routine.
     ///
     /// This method is called recursively until every `Node` in the tree is exhausted.
-    fn export_rec(&mut self, node_id: &NodeID, parser: &Parser) -> fmt::Result;
+    fn export_rec(&mut self, node_id: &NodeID, parser: &Parser) -> Result<()>;
     /// The canonical name of the exporting backend
     /// REVIEW: make public?
     fn backend_name() -> &'static str;

--- a/crates/org-exporter/src/types.rs
+++ b/crates/org-exporter/src/types.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 use org_parser::{NodeID, Parser};
-use std::{ops::Range, path::PathBuf};
+use std::{fmt::Display, ops::Range, path::PathBuf};
 use thiserror::Error;
 
 pub(crate) type Result<T> = core::result::Result<T, ExportError>;
@@ -33,7 +33,7 @@ pub enum LogicErrorKind {
 }
 
 #[derive(Debug, Error)]
-#[error("{context} {path}: {source}")]
+#[error("{context}`{path}`: {source}")]
 pub struct FileError {
     pub context: String,
     pub path: PathBuf,

--- a/crates/org-exporter/src/types.rs
+++ b/crates/org-exporter/src/types.rs
@@ -3,8 +3,6 @@ use org_parser::{NodeID, Parser};
 use std::{ops::Range, path::PathBuf};
 use thiserror::Error;
 
-pub(crate) type Result<T> = core::result::Result<T, ExportError>;
-
 use crate::{include::IncludeError, org_macros::MacroError};
 
 #[derive(Debug, Clone, Default)]
@@ -20,8 +18,6 @@ pub enum ExportError {
         span: Range<usize>,
         source: LogicErrorKind,
     },
-    #[error("{0}")]
-    WriteError(#[from] fmt::Error),
 }
 
 #[derive(Debug, Error)]
@@ -75,7 +71,7 @@ pub trait Exporter<'buf> {
 pub(crate) trait ExporterInner<'buf> {
     /// Entry point of the exporter to handle macros.
     ///
-    /// Exporting macros entails creating a new context and parsing objects,
+    /// Exporting macros entails creating a new context which parses objects,
     /// as opposed to elements.
     fn export_macro_buf<'inp, T: fmt::Write>(
         input: &'inp str,
@@ -85,7 +81,7 @@ pub(crate) trait ExporterInner<'buf> {
     /// Primary exporting routine.
     ///
     /// This method is called recursively until every `Node` in the tree is exhausted.
-    fn export_rec(&mut self, node_id: &NodeID, parser: &Parser) -> Result<()>;
+    fn export_rec(&mut self, node_id: &NodeID, parser: &Parser);
     /// The canonical name of the exporting backend
     /// REVIEW: make public?
     fn backend_name() -> &'static str;

--- a/crates/org-exporter/src/types.rs
+++ b/crates/org-exporter/src/types.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 use org_parser::{NodeID, Parser};
-use std::{fmt::Display, ops::Range, path::PathBuf};
+use std::{ops::Range, path::PathBuf};
 use thiserror::Error;
 
 pub(crate) type Result<T> = core::result::Result<T, ExportError>;
@@ -54,18 +54,18 @@ impl ConfigOptions {
 /// Exporting backends must implement this trait.
 pub trait Exporter<'buf> {
     /// Writes the AST generated from the input into a `String`.
-    fn export(input: &str, conf: ConfigOptions) -> Result<String>;
+    fn export(input: &str, conf: ConfigOptions) -> core::result::Result<String, Vec<ExportError>>;
     /// Writes the AST generated from the input into a buffer that implements `Write`.
     fn export_buf<'inp, T: fmt::Write>(
         input: &'inp str,
         buf: &'buf mut T,
         conf: ConfigOptions,
-    ) -> Result<()>;
+    ) -> core::result::Result<(), Vec<ExportError>>;
     fn export_tree<T: fmt::Write>(
         parsed: &Parser,
         buf: &'buf mut T,
         conf: ConfigOptions,
-    ) -> Result<()>;
+    ) -> core::result::Result<(), Vec<ExportError>>;
 
     // fn errors(&self) -> Vec<ExportError>;
     // fn warnings(&self);
@@ -81,7 +81,7 @@ pub(crate) trait ExporterInner<'buf> {
         input: &'inp str,
         buf: &'buf mut T,
         conf: ConfigOptions,
-    ) -> Result<()>;
+    ) -> core::result::Result<(), Vec<ExportError>>;
     /// Primary exporting routine.
     ///
     /// This method is called recursively until every `Node` in the tree is exhausted.
@@ -90,4 +90,5 @@ pub(crate) trait ExporterInner<'buf> {
     /// REVIEW: make public?
     fn backend_name() -> &'static str;
     fn config_opts(&self) -> &ConfigOptions;
+    fn errors(&mut self) -> &mut Vec<ExportError>;
 }

--- a/crates/org-exporter/src/utils.rs
+++ b/crates/org-exporter/src/utils.rs
@@ -181,7 +181,7 @@ ul {
 
 "#,
             ConfigOptions::default(),
-        )?;
+        ).unwrap();
         println!("{a}");
         Ok(())
     }

--- a/crates/org-parser/Cargo.toml
+++ b/crates/org-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "org-rust-parser"
-version = "0.1.4"
+version = "0.1.5"
 description = "parser for org mode documents"
 
 homepage.workspace = true

--- a/crates/org-parser/src/element/comment.rs
+++ b/crates/org-parser/src/element/comment.rs
@@ -17,7 +17,7 @@ impl<'a> Parseable<'a> for Comment<'a> {
         if cursor.peek(1)?.is_ascii_whitespace() {
             let prev = cursor.index;
             cursor.adv_till_byte(NEWLINE);
-            let val = bytes_to_str(&cursor.byte_arr[prev..cursor.index]);
+            let val = bytes_to_str(&cursor.byte_arr[(prev + 2)..cursor.index]);
             // TODO: use an fn_until_inclusive to not have to add 1 to the end
             // (we want to eat the ending nl too)
             Ok(parser.alloc(Self(val), start, cursor.index + 1, parent))

--- a/crates/org-parser/src/element/drawer.rs
+++ b/crates/org-parser/src/element/drawer.rs
@@ -30,7 +30,7 @@ impl<'a> Parseable<'a> for Drawer<'a> {
         parse_opts: ParseOpts,
     ) -> Result<NodeID> {
         let start = cursor.index;
-        cursor.is_index_valid()?;
+        cursor.curr_valid()?;
         cursor.skip_ws();
         cursor.word(":")?;
 
@@ -85,8 +85,8 @@ impl<'a> Parseable<'a> for Drawer<'a> {
 pub type PropertyDrawer<'a> = HashMap<&'a str, Cow<'a, str>>;
 
 pub(crate) fn parse_property(mut cursor: Cursor) -> Result<Match<PropertyDrawer>> {
+    cursor.curr_valid()?;
     let start = cursor.index;
-    cursor.is_index_valid()?;
     cursor.skip_ws();
     cursor.word(":")?;
 

--- a/crates/org-parser/src/element/drawer.rs
+++ b/crates/org-parser/src/element/drawer.rs
@@ -30,7 +30,6 @@ impl<'a> Parseable<'a> for Drawer<'a> {
         parse_opts: ParseOpts,
     ) -> Result<NodeID> {
         let start = cursor.index;
-        cursor.curr_valid()?;
         cursor.skip_ws();
         cursor.word(":")?;
 
@@ -43,7 +42,7 @@ impl<'a> Parseable<'a> for Drawer<'a> {
         cursor.index = name_match.end;
         cursor.word(":")?;
         cursor.skip_ws();
-        if cursor.curr() != NEWLINE {
+        if cursor.try_curr()? != NEWLINE {
             return Err(MatchError::InvalidLogic);
         }
         cursor.next();
@@ -99,7 +98,7 @@ pub(crate) fn parse_property(mut cursor: Cursor) -> Result<Match<PropertyDrawer>
 
     cursor.word(":")?;
     cursor.skip_ws();
-    if cursor.curr() != NEWLINE {
+    if cursor.try_curr()? != NEWLINE {
         return Err(MatchError::InvalidLogic);
     }
     cursor.next();

--- a/crates/org-parser/src/element/item.rs
+++ b/crates/org-parser/src/element/item.rs
@@ -236,7 +236,7 @@ fn parse_counter_set(mut cursor: Cursor) -> Result<Match<&str>> {
 fn parse_tag(mut cursor: Cursor) -> Result<Match<&str>> {
     // - [@A] [X] | our tag is here :: remainder
     let start = cursor.index;
-    cursor.is_index_valid()?;
+    cursor.curr_valid()?;
     cursor.skip_ws();
 
     let end = loop {
@@ -286,12 +286,12 @@ impl From<&CheckBox> for &str {
 impl CheckBox {
     fn parse(mut cursor: Cursor) -> Result<Match<CheckBox>> {
         let start = cursor.index;
-        cursor.is_index_valid()?;
         cursor.skip_ws();
         // we're at a LBRACK in theory here
         // 012
         // [ ]
-        if cursor.curr() != LBRACK && cursor.peek(2)? != RBRACK {
+
+        if cursor.try_curr()? != LBRACK || cursor.peek(2)? != RBRACK {
             return Err(MatchError::InvalidLogic);
         }
 

--- a/crates/org-parser/src/element/keyword.rs
+++ b/crates/org-parser/src/element/keyword.rs
@@ -163,19 +163,18 @@ impl<'a> Parseable<'a> for Keyword<'a> {
             _ => {}
         }
 
-        let prev = cursor.index;
-        cursor.adv_till_byte(NEWLINE);
         // not mentioned in the spec, but org-element trims
-        let val = bytes_to_str(&cursor.byte_arr[prev..cursor.index].trim_ascii());
+        let val = cursor.fn_until(|chr: u8| chr == b'\n')?;
+        let trimmed = val.obj.trim_ascii();
 
-        parser.keywords.insert(key_word.obj, val);
+        parser.keywords.insert(key_word.obj, trimmed);
         Ok(parser.alloc(
             Keyword {
                 key: key_word.obj,
-                val,
+                val: trimmed,
             },
             start,
-            cursor.index + 1,
+            val.end + 1,
             parent,
         ))
     }

--- a/crates/org-parser/src/element/latex_env.rs
+++ b/crates/org-parser/src/element/latex_env.rs
@@ -27,7 +27,7 @@ impl<'a> Parseable<'a> for LatexEnv<'a> {
         let name = name_match.obj;
 
         let a = format!(r"(?m)^[ \t]*\\end{{{name}}}[\t ]*$");
-        // HACK: i simplt cannot figure out how to properly escape the curls in the regex.
+        // HACK/FIXME: i simply cannot figure out how to properly escape the curls in the regex.
         // always getting hit with:
         // error: repetition quantifier expects a valid decimal
         let a = a.replace("{", r"\{");

--- a/crates/org-parser/src/element/table.rs
+++ b/crates/org-parser/src/element/table.rs
@@ -90,7 +90,7 @@ impl<'a> Parseable<'a> for TableRow {
         // TODO: doesn't play well with lists
         // should break if the indentation is not even for the next element in the list
         // but shouldn't break otherwise
-        cursor.is_index_valid()?;
+        cursor.curr_valid()?;
         cursor.skip_ws();
         cursor.word("|")?;
 

--- a/crates/org-parser/src/node_pool.rs
+++ b/crates/org-parser/src/node_pool.rs
@@ -10,6 +10,11 @@ use crate::types::{Expr, Node};
 /// sequentially and cannot re-used.
 pub struct NodeID(u32);
 
+/// This exists ONLY for testing purposes
+pub(crate) fn make_node_id(id: u32) -> NodeID {
+    NodeID(id)
+}
+
 impl Display for NodeID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("{}", self.0))

--- a/crates/org-parser/src/object/latex_frag.rs
+++ b/crates/org-parser/src/object/latex_frag.rs
@@ -152,7 +152,7 @@ impl<'a> Parseable<'a> for LatexFragment<'a> {
                         return Ok(parser.alloc(entity, start, end_name_ind, parent));
                     }
 
-                    match cursor.curr() {
+                    match cursor.try_curr()? {
                         LBRACE => {
                             cursor.next();
                             loop {
@@ -471,5 +471,13 @@ c}
 
         dbg!(&pool);
         pool.print_tree();
+    }
+
+    #[test]
+    fn single_backslash_char_eof() {
+        let input = r"   \s";
+        let pool = parse_org(input);
+        let item = expr_in_pool!(pool, Plain).unwrap();
+        assert_eq!(item, &r"\s");
     }
 }

--- a/crates/org-parser/src/object/node_property.rs
+++ b/crates/org-parser/src/object/node_property.rs
@@ -16,7 +16,7 @@ pub(crate) fn parse_node_property<'a>(
     properties: &mut PropertyDrawer<'a>,
     // end index
 ) -> Result<usize> {
-    cursor.is_index_valid()?;
+    cursor.curr_valid()?;
     let start = cursor.index;
     cursor.skip_ws();
     cursor.word(":")?;

--- a/crates/org-parser/src/parse.rs
+++ b/crates/org-parser/src/parse.rs
@@ -26,7 +26,7 @@ pub(crate) fn parse_element<'a>(
         return Ok(*id);
     }
 
-    cursor.is_index_valid()?;
+    cursor.curr_valid()?;
     // means a newline checking thing called this, and newline breaks all
     // table rows
     if parse_opts.markup.contains(MarkupKind::Table) {

--- a/crates/org-parser/src/types.rs
+++ b/crates/org-parser/src/types.rs
@@ -64,7 +64,7 @@ pub(crate) fn process_attrs<'a>(
                 // allows for non-breaking colons:
                 // #+attr_html: :style border:2px solid black
                 loop {
-                    match cursor.curr() {
+                    match cursor.try_curr()? {
                         NEWLINE => break,
                         COLON => {
                             if cursor.peek_rev(1)?.is_ascii_whitespace() {

--- a/crates/org-parser/src/types.rs
+++ b/crates/org-parser/src/types.rs
@@ -273,7 +273,7 @@ impl<'a> Cursor<'a> {
             .ok_or(MatchError::EofError)
     }
 
-    pub fn is_index_valid(&self) -> Result<()> {
+    pub fn curr_valid(&self) -> Result<()> {
         if self.index < self.byte_arr.len() {
             Ok(())
         } else {
@@ -291,8 +291,12 @@ impl<'a> Cursor<'a> {
     }
 
     pub fn skip_ws(&mut self) {
-        while self.curr() == SPACE {
-            self.next();
+        while let Ok(curr_item) = self.try_curr() {
+            if self.curr() == SPACE {
+                self.next()
+            } else {
+                break;
+            }
         }
     }
 

--- a/crates/org-wasm/main.js
+++ b/crates/org-wasm/main.js
@@ -200,7 +200,7 @@ function toggleView(name, button_name) {
 }
 
 function reparse() {
-  const result = parse_func(editor.state.doc.toString().concat("\n"));
+  const result = parse_func(editor.state.doc.toString());
   // actually changing srcdoc causes extreme white flashing.
   // updating the iframe like this is much better
   if (currElem === view_dict["rendered"]) {

--- a/crates/org-wasm/src/lib.rs
+++ b/crates/org-wasm/src/lib.rs
@@ -43,15 +43,20 @@ impl WasmExport {
     #[wasm_bindgen]
     pub fn to_org(&mut self, s: &str) -> JsValue {
         self.string_buf.clear();
-        Org::export_buf(s, &mut self.string_buf, ConfigOptions::default()).unwrap();
-        JsValue::from_str(&self.string_buf)
+        match Org::export_buf(s, &mut self.string_buf, ConfigOptions::default()) {
+            Ok(_) => JsValue::from_str(&self.string_buf),
+            Err(e) => JsValue::from_str(&e.to_string()),
+        }
     }
 
     #[wasm_bindgen]
     pub fn to_html(&mut self, s: &str) -> JsValue {
         self.string_buf.clear();
-        Html::export_buf(s, &mut self.string_buf, ConfigOptions::default()).unwrap();
-        JsValue::from_str(&self.string_buf)
+
+        match Html::export_buf(s, &mut self.string_buf, ConfigOptions::default()) {
+            Ok(_) => JsValue::from_str(&self.string_buf),
+            Err(e) => JsValue::from_str(&e.to_string()),
+        }
     }
 }
 

--- a/pkg/aur/PKGBUILD
+++ b/pkg/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: aquabeam <laithbahodi@gmail.com>
 
 pkgname=org-rust
-pkgver=0.1.16
+pkgver=0.1.17
 pkgrel=1
 url=https://github.com/hydrobeam/org-rust
 pkgdesc='CLI tool for converting Org-Mode documents to other formats'


### PR DESCRIPTION
## Goal
Make it so that `org-rust` never panics and instead does what it's supposed to do / provide a reasonable user-facing error.

A lot of these cases were due to improper EOF handling in the parser, but there were other more general errors that should not have been happening.


## contents
The commits describe the changes. 

tldr: A lot of bug fixes and more tests to make sure these issues don't happen again